### PR TITLE
Pull JSON decoding into a method in the http module

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -5,7 +5,7 @@ use url::form_urlencoded;
 
 use error::Error;
 use http;
-use response::{EtcdResult, LeaderStats};
+use response::{EtcdResult, LeaderStats, SelfStats};
 
 /// API client for etcd.
 #[derive(Debug)]
@@ -114,6 +114,17 @@ impl Client {
     /// Fails if JSON decoding fails, which suggests a bug in our schema.
     pub fn leader_stats(&self) -> Result<LeaderStats, Error> {
         let url = format!("{}v2/stats/leader", self.root_url);
+        let response = try!(http::get(url));
+        http::decode(response)
+    }
+
+    /// Returns statistics on the current node in the cluster.
+    ///
+    /// # Failures
+    ///
+    /// Fails if JSON decoding fails, which suggests a bug in our schema.
+    pub fn self_stats(&self) -> Result<SelfStats, Error> {
+        let url = format!("{}v2/stats/self", self.root_url);
         let response = try!(http::get(url));
         http::decode(response)
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,8 +1,5 @@
 use std::collections::HashMap;
-use std::io::Read;
 
-use hyper::status::StatusCode;
-use rustc_serialize::json;
 use url::{ParseError, Url};
 use url::form_urlencoded;
 
@@ -87,14 +84,8 @@ impl Client {
         let mut url = Url::parse(&base_url[..]).unwrap();
         url.set_query_from_pairs(query_pairs.iter().map(|(k, v)| (*k, *v)));
 
-        let mut response = try!(http::get(format!("{}", url)));
-        let mut response_body = String::new();
-        response.read_to_string(&mut response_body).unwrap();
-
-        match response.status {
-            StatusCode::Ok => Ok(json::decode(&response_body).unwrap()),
-            _ => Err(Error::Etcd(json::decode(&response_body).unwrap())),
-        }
+        let response = try!(http::get(format!("{}", url)));
+        http::decode(response)
     }
 
     /// Sets the key to the given value with the given time to live in seconds. Any previous value
@@ -123,14 +114,8 @@ impl Client {
     /// Fails if JSON decoding fails, which suggests a bug in our schema.
     pub fn leader_stats(&self) -> Result<LeaderStats, Error> {
         let url = format!("{}v2/stats/leader", self.root_url);
-        let mut response = try!(http::get(url));
-        let mut response_body = String::new();
-        try!(response.read_to_string(&mut response_body));
-
-        match response.status {
-            StatusCode::Ok => Ok(json::decode(&response_body).unwrap()),
-            _ => Err(Error::Etcd(json::decode(&response_body).unwrap()))
-        }
+        let response = try!(http::get(url));
+        http::decode(response)
     }
 
     // private
@@ -164,14 +149,8 @@ impl Client {
         let mut url = Url::parse(&base_url[..]).unwrap();
         url.set_query_from_pairs(query_pairs.iter().map(|(k, v)| (*k, *v)));
 
-        let mut response = try!(http::delete(format!("{}", url)));
-        let mut response_body = String::new();
-        response.read_to_string(&mut response_body).unwrap();
-
-        match response.status {
-            StatusCode::Ok => Ok(json::decode(&response_body).unwrap()),
-            _ => Err(Error::Etcd(json::decode(&response_body).unwrap())),
-        }
+        let response = try!(http::delete(format!("{}", url)));
+        http::decode(response)
     }
 
     /// Handles all set operations.
@@ -204,13 +183,7 @@ impl Client {
 
         let body = form_urlencoded::serialize(&options);
 
-        let mut response = try!(http::put(url, body));
-        let mut response_body = String::new();
-        response.read_to_string(&mut response_body).unwrap();
-
-        match response.status {
-            StatusCode::Created | StatusCode::Ok => Ok(json::decode(&response_body).unwrap()),
-            _ => Err(Error::Etcd(json::decode(&response_body).unwrap())),
-        }
+        let response = try!(http::put(url, body));
+        http::decode(response)
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -117,6 +117,10 @@ impl Client {
     }
 
     /// Returns statistics on the leader member of a cluster.
+    ///
+    /// # Failures
+    ///
+    /// Fails if JSON decoding fails, which suggests a bug in our schema.
     pub fn leader_stats(&self) -> Result<LeaderStats, Error> {
         let url = format!("{}v2/stats/leader", self.root_url);
         let mut response = try!(http::get(url));
@@ -124,8 +128,8 @@ impl Client {
         try!(response.read_to_string(&mut response_body));
 
         match response.status {
-            StatusCode::Ok => Ok(try!(json::decode(&response_body))),
-            _ => Err(Error::Etcd(try!(json::decode(&response_body))))
+            StatusCode::Ok => Ok(json::decode(&response_body).unwrap()),
+            _ => Err(Error::Etcd(json::decode(&response_body).unwrap()))
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 use std::convert::From;
-
 use hyper::HttpError;
+use std::io::Error as IoError;
+use rustc_serialize::json::DecoderError;
 
 /// An error returned by `Client` when an API call fails.
 #[derive(Debug)]
@@ -9,6 +10,8 @@ pub enum Error {
     Etcd(EtcdError),
     /// An HTTP error from attempting to connect to etcd.
     Http(HttpError),
+    Io(IoError),
+    JsonDecoderError(DecoderError),
 }
 
 /// An error returned by etcd.
@@ -28,5 +31,17 @@ pub struct EtcdError {
 impl From<HttpError> for Error {
     fn from(error: HttpError) -> Error {
         Error::Http(error)
+    }
+}
+
+impl From<IoError> for Error {
+    fn from(error: IoError) -> Error {
+        Error::Io(error)
+    }
+}
+
+impl From<DecoderError> for Error {
+    fn from(error: DecoderError) -> Error {
+        Error::JsonDecoderError(error)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,7 +10,9 @@ pub enum Error {
     Etcd(EtcdError),
     /// An HTTP error from attempting to connect to etcd.
     Http(HttpError),
+    /// An IO error, which can happen when reading the HTTP response.
     Io(IoError),
+    /// An error that occurs when the JSON response does not match the expected data structure.
     JsonDecoderError(DecoderError),
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,6 @@
 use std::convert::From;
 use hyper::HttpError;
 use std::io::Error as IoError;
-use rustc_serialize::json::DecoderError;
 
 /// An error returned by `Client` when an API call fails.
 #[derive(Debug)]
@@ -12,8 +11,6 @@ pub enum Error {
     Http(HttpError),
     /// An IO error, which can happen when reading the HTTP response.
     Io(IoError),
-    /// An error that occurs when the JSON response does not match the expected data structure.
-    JsonDecoderError(DecoderError),
 }
 
 /// An error returned by etcd.
@@ -39,11 +36,5 @@ impl From<HttpError> for Error {
 impl From<IoError> for Error {
     fn from(error: IoError) -> Error {
         Error::Io(error)
-    }
-}
-
-impl From<DecoderError> for Error {
-    fn from(error: DecoderError) -> Error {
-        Error::JsonDecoderError(error)
     }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -36,7 +36,6 @@ pub fn decode<T: Decodable>(mut response: Response) -> Result<T, Error> {
     }
 }
 
-
 // private
 
 /// Makes a request to etcd.

--- a/src/response.rs
+++ b/src/response.rs
@@ -74,3 +74,51 @@ pub struct LatencyStats {
     pub minimum: Option<f64>,
     pub standardDeviation: Option<f64>,
 }
+
+/// Statistics about an etcd cluster node.
+#[derive(Clone, Debug, RustcDecodable)]
+#[allow(non_snake_case)]
+pub struct SelfStats {
+    /// A unique identifier for this member.
+    pub id: String,
+    /// Information about the cluster leader.
+    pub leaderInfo: LeaderInfo,
+    /// This node's name.
+    pub name: String,
+    /// Number of append requests this node has processed.
+    pub recvAppendRequestCnt: u64,
+    /// Number of requests that this node has sent.
+    pub sendAppendRequestCnt: u64,
+    /// Number of bytes per second this node is receiving (follower only).
+    pub recvBandwidthRate: Option<f64>,
+    /// Number of requests per second this node is receiving (follower only).
+    pub recvPkgRate: Option<f64>,
+    /// Number of bytes per second this node is sending (leader only). This value is undefined on single member clusters.
+    pub sendBandwidthRate: Option<f64>,
+    /// Number of requests per second this node is sending (leader only). This value is undefined on single member clusters.
+    pub sendPkgRate: Option<f64>,
+    /// Either leader or follower.
+    pub state: NodeState,
+    /// The time when this node was started.
+    pub startTime: String,
+}
+
+/// Information about a leader, included with node statistics.
+#[derive(Clone, Debug, RustcDecodable)]
+#[allow(non_snake_case)]
+pub struct LeaderInfo {
+    /// The leader's unique identifier.
+    pub leader: String,
+    /// The time the leader was started.
+    pub startTime: String,
+    /// The amount of time the leader has been leader.
+    pub uptime: String,
+}
+
+/// State of a node
+#[derive(Clone, Debug, RustcDecodable)]
+#[allow(non_snake_case)]
+pub enum NodeState {
+    StateLeader,
+    StateFollower,
+}

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use error::Error;
 
 /// Returned by `Client` API calls. A result containing an etcd `Response` or an `Error`.
@@ -35,4 +36,41 @@ pub struct Node {
     pub ttl: Option<i64>,
     /// The value of the key.
     pub value: Option<String>,
+}
+
+/// Statistics about an etcd cluster leader.
+#[derive(Clone, Debug, RustcDecodable)]
+#[allow(non_snake_case)]
+pub struct LeaderStats {
+    /// A unique identifier of a leader member.
+    pub leader: String,
+    /// Statistics for each peer in the cluster keyed by each peer's unique identifier.
+    pub followers: HashMap<String, FollowerStats>,
+}
+
+/// Statistics on the health of a single follower.
+#[derive(Clone, Debug, RustcDecodable)]
+#[allow(non_snake_case)]
+pub struct FollowerStats {
+    /// Counts of Raft RPC request successes and failures to this follower.
+    pub counts: Option<CountStats>,
+    /// Latency statistics for this follower.
+    pub latency: Option<LatencyStats>,
+}
+
+#[derive(Clone, Debug, RustcDecodable)]
+#[allow(non_snake_case)]
+pub struct CountStats {
+    pub fail: Option<u64>,
+    pub success: Option<u64>,
+}
+
+#[derive(Clone, Debug, RustcDecodable)]
+#[allow(non_snake_case)]
+pub struct LatencyStats {
+    pub average: Option<f64>,
+    pub current: Option<f64>,
+    pub maximum: Option<f64>,
+    pub minimum: Option<f64>,
+    pub standardDeviation: Option<f64>,
 }

--- a/tests/client_test.rs
+++ b/tests/client_test.rs
@@ -2,13 +2,17 @@ extern crate etcd;
 
 use etcd::{Client, Error};
 
+fn client() -> Client {
+    Client::new("http://etcd:2379").unwrap()
+}
+
 #[test]
 fn lifecycle() {
-    let client = Client::new("http://etcd:2379").unwrap();
+    let client = client();
 
     // Creating a key
 
-    let create_response = client.create("/foo", "bar", Some(60)).ok().unwrap();
+    let create_response = client.create("/foo", "bar", Some(60)).unwrap();
 
     assert_eq!(create_response.action, "create".to_string());
     assert_eq!(create_response.node.value.unwrap(), "bar".to_string());
@@ -103,7 +107,10 @@ fn lifecycle() {
 
 #[test]
 fn leader_stats() {
-    let client = Client::new("http://etcd:2379").unwrap();
+    client().leader_stats().unwrap();
+}
 
-    client.leader_stats().unwrap();
+#[test]
+fn self_stats() {
+    client().self_stats().unwrap();
 }

--- a/tests/client_test.rs
+++ b/tests/client_test.rs
@@ -100,3 +100,10 @@ fn lifecycle() {
     client.delete("/dir/baz", false).ok();
     client.delete_dir("/dir").ok();
 }
+
+#[test]
+fn leader_stats() {
+    let client = Client::new("http://etcd:2379").unwrap();
+
+    client.leader_stats().unwrap();
+}


### PR DESCRIPTION
This is an idea I had while going through and using `try!` everywhere we're reading the response into a string in order to propagate IO errors instead of panicking. It works well, but a potential downside is that it accepts `StatusCode::Created` as a successful response code for all requests, rather than just for "set" operations as before. Not sure whether or not that's a dealbreaker for this approach.

(Based on #2.)
